### PR TITLE
[FEAT] Custom API 추가 구현(전체 리스트 타이핑)

### DIFF
--- a/src/main/java/com/awesome/typing1/domain/controller/CustomController.java
+++ b/src/main/java/com/awesome/typing1/domain/controller/CustomController.java
@@ -20,7 +20,7 @@ public class CustomController {
     private final CustomQueryService customQueryService;
 
     @PostMapping("/users/{userId}/customs/create")
-    @Operation(summary = "커스텀 타이핑 텍스트를 생성하는 api")
+    @Operation(summary = "커스텀 텍스트를 생성하는 api")
     public ApiResponse<CustomResponseDTO.CreateCustomResultDTO> createCustom(
             @PathVariable Long userId,
             @RequestBody CustomRequestDTO.CreateCustomDTO createCustomDTO) {
@@ -30,7 +30,7 @@ public class CustomController {
     }
 
     @PutMapping("/customs/{customId}")
-    @Operation(summary = "커스텀 타이핑 텍스트를 업데이트하는 api")
+    @Operation(summary = "커스텀 텍스트를 업데이트하는 api")
     public ApiResponse<String> updateCustom(
             @PathVariable Long customId,
             @RequestBody CustomRequestDTO.UpdateCustomDTO updateCustomDTO) {
@@ -40,20 +40,29 @@ public class CustomController {
     }
 
     @DeleteMapping("/customs/{customId}")
-    @Operation(summary = "커스텀 타이핑 텍스트를 soft 삭제하는 api")
+    @Operation(summary = "커스텀 텍스트를 soft 삭제하는 api")
     public ApiResponse<String> deleteCustom(@PathVariable Long customId) {
 
         customCommandService.deleteCustom(customId);
         return ApiResponse.onSuccess("커스텀 텍스트 삭제에 성공하였습니다.");
     }
 
-    @GetMapping("/users/{userId}/customs")
-    @Operation(summary = "커스텀 타이핑 텍스트 리스트를 가져오는 api")
+    @GetMapping("/users/{userId}/customs/preview")
+    @Operation(summary = "커스텀 텍스트 미리보기 리스트를 가져오는 api")
     public ApiResponse<CustomResponseDTO.CustomPreviewListDTO> previewCustoms(
             @PathVariable Long userId,
             @RequestParam(defaultValue = "0") int page) {
 
         return ApiResponse.onSuccess(customQueryService.previewCustoms(userId, page));
+    }
+
+    @GetMapping("/users/{userId}/customs")
+    @Operation(summary = "커스텀 텍스트 자세히보기 리스트를 가져오는 api")
+    public ApiResponse<CustomResponseDTO.CustomViewListDTO> viewCustoms(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page) {
+
+        return ApiResponse.onSuccess(customQueryService.viewCustoms(userId, page));
     }
 
 }

--- a/src/main/java/com/awesome/typing1/domain/converter/CustomConverter.java
+++ b/src/main/java/com/awesome/typing1/domain/converter/CustomConverter.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public class CustomConverter {
 
+    // 커스텀 텍스트 생성 시 사용
     public static Custom toCustom(CustomRequestDTO.CreateCustomDTO createCustomDTO) {
 
         return Custom.builder()
@@ -21,6 +22,7 @@ public class CustomConverter {
                 .build();
     }
 
+    // 커스텀 텍스트 생성 후, 생성의 결과로 변환 시에 사용
     public static CustomResponseDTO.CreateCustomResultDTO toCreateCustomResultDTO(Custom custom) {
 
         return CustomResponseDTO.CreateCustomResultDTO.builder()
@@ -32,6 +34,7 @@ public class CustomConverter {
                 .build();
     }
 
+    // 커스텀 텍스트를 미리보기 DTO 로 변환 시에 사용
     public static CustomResponseDTO.CustomPreviewDTO toCustomPreviewDTO(Custom custom) {
 
         return CustomResponseDTO.CustomPreviewDTO.builder()
@@ -43,6 +46,7 @@ public class CustomConverter {
                 .build();
     }
 
+    // 페이징된 커스텀 텍스트를, 페이징된 미리보기로 변환 시에 사용
     public static CustomResponseDTO.CustomPreviewListDTO toCustomPreviewListDTO(Page<Custom> customs) {
 
         // Page<Custom> 내의 각 Custom 에 대하여 CustomPreviewDTO 객체로 변환
@@ -51,14 +55,41 @@ public class CustomConverter {
                 .toList();
 
         // List<CustomResponseDTO.CustomPreviewDTO> 페이징 및 페이지응답으로 변환
-        PageResponse<CustomResponseDTO.CustomPreviewDTO> customPageResponse = toCustomPageResponse(new PageImpl<>(customPreviewDTOs, customs.getPageable(), customs.getTotalElements()));
+        PageResponse<CustomResponseDTO.CustomPreviewDTO> customPreviewDTOPageResponse = toCustomPageResponse(new PageImpl<>(customPreviewDTOs));
 
         return CustomResponseDTO.CustomPreviewListDTO.builder()
-                .customPreviewDTOS(customPageResponse)
+                .customPreviewDTOs(customPreviewDTOPageResponse)
                 .build();
 
     }
 
+    // 커스텀 텍스트를 자세히보기 DTO 로 변환 시에 사용
+    public static CustomResponseDTO.CustomViewDTO toCustomViewDTO(Custom custom) {
+
+        return CustomResponseDTO.CustomViewDTO.builder()
+                .id(custom.getId())
+                .userId(custom.getUser().getId())
+                .title(custom.getTitle())
+                .content(custom.getContent())
+                .source(custom.getSource())
+                .build();
+    }
+
+    // 페이징된 커스텀 텍스트를, 페이징된 자세히보기로 변환 시에 사용
+    public static CustomResponseDTO.CustomViewListDTO toCustomViewListDTO(Page<Custom> customs) {
+
+        List<CustomResponseDTO.CustomViewDTO> customViewDTOs = customs.getContent().stream()
+                .map(CustomConverter::toCustomViewDTO)
+                .toList();
+
+        PageResponse<CustomResponseDTO.CustomViewDTO> customViewDTOPageResponse = toCustomPageResponse(new PageImpl<>(customViewDTOs));
+
+        return CustomResponseDTO.CustomViewListDTO.builder()
+                .customViewDTOs(customViewDTOPageResponse)
+                .build();
+    }
+
+    // Page<>를 페이지응답으로 변환
     public static <T> PageResponse<T> toCustomPageResponse(Page<T> customPreviewDTOs) {
         return new PageResponse<>(
                 customPreviewDTOs.getContent(), // 현재 페이지의 데이터

--- a/src/main/java/com/awesome/typing1/domain/dto/response/CustomResponseDTO.java
+++ b/src/main/java/com/awesome/typing1/domain/dto/response/CustomResponseDTO.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class CustomResponseDTO {
 
@@ -27,8 +26,10 @@ public class CustomResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    // 특정 사용자의 커스텀 텍스트 하나 미리보기
     public static class CustomPreviewDTO {
-        private Long userId; // 데이터 확인 목적으로 추가, but 실제로는 필요없을 수 있기 때문에 제거할 수도
+        private Long id; // 커스텀 텍스트 아이디
+        private Long userId; // id와 userId는 데이터 확인 목적으로 추가, but 실제로는 필요없을 수 있기 때문에 제거할 수도
         private String title; // 제목
         private String source; // 출처(저자)
         private LocalDateTime createdAt; // 텍스트 작성일
@@ -39,7 +40,32 @@ public class CustomResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    // 특정 사용자의 커스텀 텍스트 리스트 미리보기
     public static class CustomPreviewListDTO {
-        private PageResponse<CustomPreviewDTO> customPreviewDTOS;
+        private PageResponse<CustomPreviewDTO> customPreviewDTOs;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // 특정 사용자의 커스텀 텍스트 하나 자세히 보기
+    public static class CustomViewDTO {
+        private Long id; // 커스텀 텍스트 아이디
+        private Long userId; // id와 userId는 데이터 확인 목적으로 추가, but 실제로는 필요없을 수 있기 때문에 제거할 수도
+        private String title; // 제목
+        private String content; // 내용
+        private String source; // 출처(저자)
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // 특정 사용자의 커스텀 텍스트 리스트 자세히 보기
+    public static class CustomViewListDTO {
+        private PageResponse<CustomViewDTO> customViewDTOs;
+    }
+
+
 }

--- a/src/main/java/com/awesome/typing1/domain/service/queryService/CustomQueryService.java
+++ b/src/main/java/com/awesome/typing1/domain/service/queryService/CustomQueryService.java
@@ -6,4 +6,6 @@ public interface CustomQueryService {
 
     CustomResponseDTO.CustomPreviewListDTO previewCustoms(Long userId, int page);
 
+    CustomResponseDTO.CustomViewListDTO viewCustoms(Long userId, int page);
+
 }

--- a/src/main/java/com/awesome/typing1/domain/service/queryService/impl/CustomQueryServiceImpl.java
+++ b/src/main/java/com/awesome/typing1/domain/service/queryService/impl/CustomQueryServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import static com.awesome.typing1.domain.converter.CustomConverter.toCustomPreviewListDTO;
+import static com.awesome.typing1.domain.converter.CustomConverter.toCustomViewListDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class CustomQueryServiceImpl implements CustomQueryService {
     private static final int PAGE_SIZE = 20;
 
     @Override
+    // 특정 사용자의 커스텀 텍스트 리스트 미리보기
     public CustomResponseDTO.CustomPreviewListDTO previewCustoms(Long userId, int page) {
 
         User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
@@ -36,5 +38,17 @@ public class CustomQueryServiceImpl implements CustomQueryService {
         Page<Custom> customs = customRepository.findActiveCustomsByUser(user, pageable);
 
         return toCustomPreviewListDTO(customs);
+    }
+
+    @Override
+    // 특정 사용자의 커스텀 텍스트 리스트 자세히 보기
+    public CustomResponseDTO.CustomViewListDTO viewCustoms(Long userId, int page) {
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Page<Custom> customs = customRepository.findActiveCustomsByUser(user, pageable);
+
+        return toCustomViewListDTO(customs);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 / ex) #이슈번호

#10 

## 📝작업 내용
#### > 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

: Custom 텍스트들을 미리보기 리스트로 받아오는 것이 아닌,
현재 리스트에 추가하기 위하여 content까지 포함된 DTO 리스트를 반환하는 API 추가 구현
